### PR TITLE
fix display implementation (preserve whole numbers)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "bumparaw-collections"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "allocator-api2",
  "bitpacking",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bumparaw-collections"
-version = "0.1.6"
+version = "0.1.7"
 description = "A small set of bumpalo-backed collections for low-level operations"
 authors = ["Louis Dureuil <louis@meilisearch.com>", "Kerollmops <clement@meilisearch.com>"]
 license = "MIT"

--- a/src/value.rs
+++ b/src/value.rs
@@ -52,7 +52,11 @@ impl Number {
     /// - If the number is infinite or NaN. This doesn't happen under normal JSON-parsing conditions,
     ///   but would if directly creating `Number::Finite(NaN)`...
     pub fn to_serde_json(self) -> serde_json::Number {
-        serde_json::Number::from_f64(self.to_f64()).unwrap()
+        match self {
+            Number::PosInt(n) => serde_json::Number::from(n),
+            Number::NegInt(n) => serde_json::Number::from(n),
+            Number::Finite(n) => serde_json::Number::from_f64(n).unwrap(),
+        }
     }
 }
 


### PR DESCRIPTION
#7 introduced a buggy display impl for Value, because a number would be unconditionally converted to a float, causing whole numbers to be displayed as floats.

This PR fixes this oversight, and several affected Meilisearch tests